### PR TITLE
Add new well-explained notebook and fix existing one

### DIFF
--- a/meep-example-resonant-cavity.ipynb
+++ b/meep-example-resonant-cavity.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simulating a Resonant Cavity with Meep"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction to Meep and FDTD\n",
+    "\n",
+    "[Meep](https://meep.readthedocs.io/en/latest/) is a free and open-source software package for electromagnetic simulations using the finite-difference time-domain (FDTD) method. FDTD is a popular method for solving Maxwell's equations, which describe how electromagnetic waves propagate and interact with materials.\n",
+    "\n",
+    "In this notebook, we will use Meep to simulate a resonant cavity, which is a structure that can trap electromagnetic waves at specific frequencies, called resonant frequencies. We will start with a simple 1D cavity and then move to a more complex 2D cavity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import meep as mp\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulating a 1D Resonant Cavity\n",
+    "\n",
+    "Let's start with a simple 1D resonant cavity. The cavity is formed by two mirrors (perfect electric conductors) separated by a distance. We will place a source inside the cavity to excite the modes and then observe how the fields evolve in time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_size = mp.Vector3(z=14)\n",
+    "geometry = [mp.Block(center=mp.Vector3(z=-7), size=mp.Vector3(mp.inf, mp.inf, 0), material=mp.metal),\n",
+    "            mp.Block(center=mp.Vector3(z=7), size=mp.Vector3(mp.inf, mp.inf, 0), material=mp.metal)]\n",
+    "\n",
+    "sources = [mp.Source(src=mp.GaussianSource(frequency=0.15, fwidth=0.1), \n",
+    "                    component=mp.Ey, \n",
+    "                    center=mp.Vector3(z=0))]\n",
+    "\n",
+    "pml_layers = [mp.PML(1.0)]\n",
+    "\n",
+    "resolution = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we create the `Simulation` object, which is the main object in Meep that brings together the geometry, sources, resolution, and other simulation parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = mp.Simulation(cell_size=cell_size,\n",
+    "                    boundary_layers=pml_layers,\n",
+    "                    geometry=geometry,\n",
+    "                    sources=sources,\n",
+    "                    resolution=resolution)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we run the simulation. We will run it for 200 time steps and visualize the electric field (Ey component) at each time step. The `mp.at_every` function allows us to specify a function to be called at certain intervals during the simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(dpi=100)\n",
+    "sim.run(mp.at_every(2, mp.plot2D(fields=mp.Ey, output_plane=mp.Volume(center=mp.Vector3(), size=mp.Vector3(z=14)))), until=200)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding the Resonant Modes\n",
+    "\n",
+    "To find the resonant modes of the cavity, we can use a tool called [Harminv](https://meep.readthedocs.io/en/latest/Python_User_Interface/#harminv). Harminv is a tool that can extract the frequencies and decay rates of the modes from the time-domain simulation data.\n",
+    "\n",
+    "We will run the simulation again, but this time we will use `Harminv` to analyze the fields at a specific point in the cavity. We will then print the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.reset_meep()\n",
+    "\n",
+    "h = mp.Harminv(mp.Ey, mp.Vector3(z=0), 0.1, 0.2)\n",
+    "\n",
+    "sim.run(after_sources=h, until_after_sources=200)\n",
+    "\n",
+    "print(h.modes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extending to a 2D Resonant Cavity\n",
+    "\n",
+    "Now, let's extend our simulation to 2D. We will create a 2D resonant cavity by using a `Cylinder` object as our cavity. The setup is similar to the 1D case, but we now have a 2D geometry and we will visualize the fields in 2D."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_size = mp.Vector3(14, 14)\n",
+    "geometry = [mp.Cylinder(radius=5, material=mp.metal)]\n",
+    "\n",
+    "sources = [mp.Source(src=mp.GaussianSource(frequency=0.15, fwidth=0.1), \n",
+    "                    component=mp.Ez, \n",
+    "                    center=mp.Vector3(0,0))]\n",
+    "\n",
+    "pml_layers = [mp.PML(1.0)]\n",
+    "\n",
+    "resolution = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = mp.Simulation(cell_size=cell_size,\n",
+    "                    boundary_layers=pml_layers,\n",
+    "                    geometry=geometry,\n",
+    "                    sources=sources,\n",
+    "                    resolution=resolution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(dpi=100)\n",
+    "sim.run(mp.at_every(0.6, mp.plot2D(fields=mp.Ez)), until=200)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion and Further Exploration\n",
+    "\n",
+    "In this notebook, we have learned how to simulate a resonant cavity in 1D and 2D using Meep. We have also seen how to use Harminv to find the resonant modes of the cavity.\n",
+    "\n",
+    "For further exploration, you can try:\n",
+    "*   Changing the geometry of the cavity (e.g., using different shapes or materials).\n",
+    "*   Using different sources to excite the modes.\n",
+    "*   Exploring other analysis tools in Meep, such as flux monitors to calculate the transmission and reflection spectra.\n",
+    "*   Extending the simulation to 3D."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/meep-example01.ipynb
+++ b/meep-example01.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Meep Tutorial: Waveguide Cavity\n",
+    "\n",
+    "This notebook simulates a waveguide cavity with a defect. It calculates the power spectral density (PSD) for a simple waveguide and a waveguide with a cavity."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -31,7 +40,12 @@
     "dpml = 1          # PML thickness\n",
     "\n",
     "sx = 2*(pad+dpml)+d-1  # size of cell in x direction\n",
-    "cell = mp.Vector3(sx,sy,0)"
+    "cell = mp.Vector3(sx,sy,0)\n",
+    "\n",
+    "pml_layers = [mp.PML(1.0)]\n",
+    "sym = [mp.Mirror(mp.Y)]\n",
+    "fcen = 0.25\n",
+    "df = 0.2"
    ]
   },
   {


### PR DESCRIPTION
This change introduces a new Python notebook, `meep-example-resonant-cavity.ipynb`, which provides a comprehensive and well-explained example of a resonant cavity simulation using Meep. The notebook is structured to be accessible for both beginners and experts, with clear markdown explanations for each code cell.

Additionally, this change fixes a `NameError` in the existing `meep-example01.ipynb` by defining the missing variables, making the notebook runnable. An introductory markdown cell has also been added to `meep-example01.ipynb` to provide context.